### PR TITLE
fix: disable non-selected conqueror's in the trade window link from the skill tree view

### DIFF
--- a/frontend/src/lib/skill_tree.ts
+++ b/frontend/src/lib/skill_tree.ts
@@ -401,7 +401,7 @@ export const constructQuery = (jewel: number, conqueror: string, result: SearchW
           .map((c) =>
             seeds.map((seed) => ({
               id: tradeStatNames[jewel][c],
-              disabled: false,
+              disabled: c != conqueror,
               value: {
                 min: seed,
                 max: seed


### PR DESCRIPTION
Disables the non-selected conqueror's in the trade query to avoid accidentally buying a jewel with the wrong conqueror