### PR TITLE
feat: add "Any" option for conqueror dropdown select and search more than 200 seeds

### DIFF
--- a/frontend/src/lib/components/SearchResult.svelte
+++ b/frontend/src/lib/components/SearchResult.svelte
@@ -1,27 +1,35 @@
 <script lang="ts">
-  import type { SearchWithSeed } from '../skill_tree';
-  import { skillTree, translateStat, openTrade } from '../skill_tree';
+  import { openQueryTrade } from '$lib/utils/trade_utils';
+  import { constructSingleResultQuery, type SearchWithSeed } from '../skill_tree';
+  import { skillTree, translateStat } from '../skill_tree';
 
   export let highlight: (newSeed: number, passives: number[]) => void;
   export let set: SearchWithSeed;
   export let jewel: number;
   export let conqueror: string;
+
+  const handleOnClick = () =>
+    highlight(
+      set.seed,
+      set.skills.map((s) => s.passive)
+    );
 </script>
 
 <div
   class="my-2 border-white/50 border p-2 flex flex-col cursor-pointer"
-  on:click={() =>
-    highlight(
-      set.seed,
-      set.skills.map((s) => s.passive)
-    )}>
+  on:click={handleOnClick}
+  on:keydown={handleOnClick}
+  role="button"
+  tabindex="0">
   <div class="flex flex-row justify-between">
     <!-- Padding -->
     <button class="px-3 invisible">Trade</button>
     <div class="font-bold text-orange-500 text-center">
       Seed {set.seed} (weight {set.weight})
     </div>
-    <button class="px-3 bg-blue-500/40 rounded" on:click={() => openTrade(jewel, conqueror, [set])}>Trade</button>
+    <button
+      class="px-3 bg-blue-500/40 rounded"
+      on:click={() => openQueryTrade(constructSingleResultQuery(jewel, conqueror, set))}>Trade</button>
   </div>
   {#each set.skills as skill}
     <div class="mt-2">

--- a/frontend/src/lib/components/TradeButton.svelte
+++ b/frontend/src/lib/components/TradeButton.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { openQueryTrade, type Query } from '$lib/utils/trade_utils';
+
+  export let queries: Query[];
+  export let showTradeLinks = false;
+
+  $: console.log(showTradeLinks);
+
+  $: hasMultipleQueries = queries.length > 1;
+
+  const handleOnClick = () => {
+    if (queries.length === 1) {
+      // if all filter fit into a single query, link straight to trade website
+      openQueryTrade(queries[0]);
+    } else if (hasMultipleQueries) {
+      // otherwise toggle display of batched trade links
+      showTradeLinks = !showTradeLinks;
+    }
+  };
+</script>
+
+<button
+  class="p-1 px-3 bg-blue-500/40 rounded disabled:bg-blue-900/40 mr-2"
+  on:click={handleOnClick}
+  disabled={!queries}>
+  {hasMultipleQueries ? (showTradeLinks ? 'Hide Trade Links' : 'Show Trade Links') : 'Trade'}
+</button>

--- a/frontend/src/lib/components/TradeLinks.svelte
+++ b/frontend/src/lib/components/TradeLinks.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { openQueryTrade, type Query } from '$lib/utils/trade_utils';
+
+  // queries to display trade link buttons for
+  export let queries: Query[];
+</script>
+
+<div class="flex flex-wrap gap-2.5 my-2">
+  {#each queries as query, index}
+    <button class="p-1 px-3 bg-blue-500/40 rounded" on:click={() => openQueryTrade(query)}>
+      Trade Batch {index + 1}
+    </button>
+  {/each}
+</div>

--- a/frontend/src/lib/utils/trade_utils.ts
+++ b/frontend/src/lib/utils/trade_utils.ts
@@ -1,0 +1,47 @@
+export type Filter = {
+  id: string;
+  value: { min: number; max: number };
+  disabled?: boolean;
+};
+export type FilterGroup = {
+  type: string;
+  value: { min: number };
+  filters: Filter[];
+  disabled: boolean;
+};
+export type Query = {
+  query: {
+    status: {
+      option: string;
+    };
+    stats: FilterGroup[];
+  };
+  sort: {
+    price: string;
+  };
+};
+
+export const filtersToFilterGroup = (filters: Filter[], disabled: boolean): FilterGroup => ({
+  type: 'count',
+  value: { min: 1 },
+  filters: filters,
+  disabled: disabled
+});
+
+export const filterGroupsToQuery = (FilterGroups: FilterGroup[]): Query => ({
+  query: {
+    status: {
+      option: 'online'
+    },
+    stats: FilterGroups
+  },
+  sort: {
+    price: 'asc'
+  }
+});
+
+export const openQueryTrade = (query: Query) => {
+  const url = new URL('https://www.pathofexile.com/trade/search/Necropolis');
+  url.searchParams.set('q', JSON.stringify(query));
+  window.open(url, '_blank');
+};

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Break an array into chunks of the given size
+ *
+ * e.g. for chunk size 2:
+ *
+ * [1, 2, 3, 4, 5] => [[1, 2], [3, 4], [5]]
+ */
+export const chunkArray = <T>(inputArray: Array<T>, chunkSize: number): Array<T>[] =>
+  inputArray.reduce((resultArray, item, index) => {
+    const chunkIndex = Math.floor(index / chunkSize);
+
+    if (!resultArray[chunkIndex]) {
+      resultArray[chunkIndex] = []; // start a new chunk
+    }
+
+    resultArray[chunkIndex].push(item);
+
+    return resultArray;
+  }, [] as Array<T>[]);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -117,8 +117,9 @@
                 {#if result.AlternatePassiveSkill}
                   <div class="mt-4">
                     <h3>Alternate Passive Skill</h3>
-                    <span
-                      >{result.AlternatePassiveSkill.Name} ({result.AlternatePassiveSkill.ID}) ({result.AlternatePassiveSkill})</span>
+                    <span>
+                      {result.AlternatePassiveSkill.Name} ({result.AlternatePassiveSkill.ID})
+                    </span>
                   </div>
 
                   {#if result.StatRolls && Object.keys(result.StatRolls).length > 0}

--- a/frontend/src/routes/tree/+page.svelte
+++ b/frontend/src/routes/tree/+page.svelte
@@ -4,13 +4,15 @@
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
   import type { Node } from '../../lib/skill_tree_types';
-  import { getAffectedNodes, skillTree, translateStat, openTrade } from '../../lib/skill_tree';
+  import { getAffectedNodes, skillTree, translateStat, constructQueries } from '../../lib/skill_tree';
   import { syncWrap } from '../../lib/worker';
   import { proxy } from 'comlink';
-  import type { ReverseSearchConfig, StatConfig } from '../../lib/skill_tree';
+  import type { Query, ReverseSearchConfig, StatConfig } from '../../lib/skill_tree';
   import SearchResults from '../../lib/components/SearchResults.svelte';
   import { statValues } from '../../lib/values';
   import { data, calculator } from '../../lib/types';
+  import TradeButton from '$lib/components/TradeButton.svelte';
+  import TradeLinks from '$lib/components/TradeLinks.svelte';
 
   const searchParams = $page.url.searchParams;
 
@@ -28,12 +30,18 @@
       }))
     : [];
 
-  let selectedConqueror = searchParams.has('conqueror')
+  $: dropdownConqs = conquerors.concat([{ value: 'Any', label: 'Any' }]);
+
+  let dropdownConqueror = searchParams.has('conqueror')
     ? {
         value: searchParams.get('conqueror'),
         label: searchParams.get('conqueror')
       }
     : undefined;
+
+  $: anyConqueror = dropdownConqueror?.value === 'Any';
+
+  $: selectedConqueror = dropdownConqueror?.value === 'Any' ? conquerors[0] : dropdownConqueror;
 
   let seed: number = searchParams.has('seed') ? parseInt(searchParams.get('seed')) : 0;
 
@@ -80,7 +88,7 @@
   const updateUrl = () => {
     const url = new URL(window.location.origin + window.location.pathname);
     selectedJewel && url.searchParams.append('jewel', selectedJewel.value.toString());
-    selectedConqueror && url.searchParams.append('conqueror', selectedConqueror.value);
+    dropdownConqueror && url.searchParams.append('conqueror', dropdownConqueror.value);
     seed && url.searchParams.append('seed', seed.toString());
     circledNode && url.searchParams.append('location', circledNode.toString());
     mode && url.searchParams.append('mode', mode);
@@ -156,14 +164,14 @@
   let currentSeed = 0;
   let searchResults: SearchResults;
   let searchJewel = 1;
-  let searchConqueror = '';
+  let searchConqueror: string | null = null;
   const search = () => {
     if (!circledNode) {
       return;
     }
 
     searchJewel = selectedJewel.value;
-    searchConqueror = selectedConqueror.value;
+    searchConqueror = anyConqueror ? null : selectedConqueror.value;
     searching = true;
     searchResults = undefined;
 
@@ -421,6 +429,20 @@
   };
 
   let collapsed = false;
+
+  let showTradeLinks = false;
+
+  let queries: Query[];
+
+  // reconstruct queries if search results change
+  $: if (searchResults && results) {
+    queries = constructQueries(searchJewel, searchConqueror, searchResults.raw);
+
+    // reset showTradeLinks to hidden if new queries is only length of 1
+    if (queries.length === 1) {
+      showTradeLinks = false;
+    }
+  }
 </script>
 
 <svelte:window on:paste={onPaste} />
@@ -453,12 +475,7 @@
           {#if searchResults}
             <div class="flex flex-row">
               {#if results}
-                <button
-                  class="p-1 px-3 bg-blue-500/40 rounded disabled:bg-blue-900/40 mr-2"
-                  on:click={() => openTrade(searchJewel, searchConqueror, searchResults.raw)}
-                  disabled={!searchResults}>
-                  Trade
-                </button>
+                <TradeButton {queries} bind:showTradeLinks />
                 <button
                   class="p-1 px-3 bg-blue-500/40 rounded disabled:bg-blue-900/40 mr-2"
                   class:grouped={groupResults}
@@ -480,7 +497,7 @@
           {#if selectedJewel}
             <div class="mt-4">
               <h3 class="mb-2">Conqueror</h3>
-              <Select items={conquerors} bind:value={selectedConqueror} on:change={updateUrl} />
+              <Select items={dropdownConqs} bind:value={dropdownConqueror} on:change={updateUrl} />
             </div>
 
             {#if selectedConqueror && Object.keys(data.TimelessJewelConquerors[selectedJewel.value]).indexOf(selectedConqueror.value) >= 0}
@@ -657,6 +674,9 @@
         {/if}
 
         {#if searchResults && results}
+          {#if showTradeLinks}
+            <TradeLinks {queries} />
+          {/if}
           <SearchResults {searchResults} {groupResults} {highlight} jewel={searchJewel} conqueror={searchConqueror} />
         {/if}
       </div>
@@ -694,7 +714,8 @@
   }
 
   .grouped {
-    @apply bg-pink-500/40 disabled:bg-pink-900/40;
+    @apply bg-pink-500/40;
+    disabled: bg-pink-900/40;
   }
 
   .rainbow {


### PR DESCRIPTION
DEMO: [https://imhamba.github.io/timeless-jewels](https://imhamba.github.io/timeless-jewels)

Added an "any" option for the conqueror drop down, for the purposes of searching the trade website.
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/509bf2ea-cecf-4047-a809-d4fdc8518693)

This selection is reflected in the url params as `conqueror=Any`, and loading a link with this param will automatically select the Any dropdown option.

This will generate trade site queries that search for the same seed for each conqueror (if you dont care about the keystone).
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/8a399d96-72c2-4e85-9769-2c9a00034fb9)

Selecting a specific conqueror will generate trade queries that only have that conqueror:
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/24173a68-46f6-4424-91e9-8a0f9211217d)

This fixes a bug mentioned in various issues:
https://github.com/Vilsol/timeless-jewels/issues/33
https://github.com/Vilsol/timeless-jewels/issues/31

Additionally, fixed issue where the all 4 count filter groups would be identical (also mentioned in above issues):
Now each count group has 50 unique seeds that the user can enable/disable to search 50 seeds at a time, for a total of 200 seeds per trade search.
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/ee95611d-10d2-4b9d-89eb-29e826acac54)
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/042f3906-b5b5-4324-8b01-f21296ac7219)
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/cdf6ddf2-b83e-4196-ae72-0973b5df6bbd)
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/f92bbcfa-17ad-455a-ac80-50edea6f20ca)

Also, previously if there were over 50x4 = 200 valid seeds, a single trade link would be generated for the first 200 (in practice just for 50 due to the above bug), any additional ones would just be truncated off and ignored. Now if there are over 200 seeds, the "trade" button becomes a toggle button to display multiple trade queries to cover the entire set of valid seeds.
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/e2e8e4eb-4c03-4ba8-bb3f-29e1806a1070)
![image](https://github.com/Vilsol/timeless-jewels/assets/129166482/5e6adcbf-e3f6-4b69-9264-a4c9f60b13fd)

So the user can now see all possible valid seeds returned by their search.