### PR TITLE
feat: add paste feature to main page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -68,7 +68,51 @@
       goto($page.url.pathname + '?' + resultQuery);
     }
   };
+
+  const onPaste = (event: ClipboardEvent) => {
+    if (event.type !== 'paste') {
+      return;
+    }
+
+    const paste = (event.clipboardData || window.clipboardData).getData('text');
+    const lines = paste.split('\n').map(line => line.trim());
+
+    if (lines.length < 14) {
+      return;
+    }
+
+    const jewel = jewels.find((j) => j.label === lines[2]);
+    if (!jewel) {
+      return;
+    }
+
+    let newSeed: number | undefined;
+    let conqueror: string | undefined;
+    for (let i = 10; i < lines.length; i++) {
+      conqueror = Object.keys(data.TimelessJewelConquerors[jewel.value]).find((k) => lines[i].indexOf(k) >= 0);
+      if (conqueror) {
+        const matches = /(\d+)/.exec(lines[i]);
+        if (matches.length === 0) {
+          continue;
+        }
+
+        newSeed = parseInt(matches[1]);
+        break;
+      }
+    }
+
+    if (!conqueror || !newSeed) {
+      return;
+    }
+
+    seed = newSeed;
+    selectedJewel = jewel;
+    selectedConqueror = { label: conqueror, value: conqueror };
+    updateUrl();
+  };
 </script>
+
+<svelte:window on:paste={onPaste} />
 
 <div class="py-10 flex flex-row justify-center w-screen h-screen">
   <div class="flex flex-col justify-between w-1/3">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -81,7 +81,7 @@
 
       <div class="themed">
         <h3 class="mb-2">Timeless Jewel</h3>
-        <Select items={jewels} bind:value={selectedJewel} on:select={updateUrl} />
+        <Select items={jewels} bind:value={selectedJewel} on:select={updateUrl} placeholder="Please select or paste jewel" />
 
         {#if selectedJewel}
           <div class="mt-4">

--- a/frontend/src/routes/tree/+page.svelte
+++ b/frontend/src/routes/tree/+page.svelte
@@ -522,7 +522,7 @@
         </div>
 
         {#if !results}
-          <Select items={jewels} bind:value={selectedJewel} on:change={changeJewel} />
+          <Select items={jewels} bind:value={selectedJewel} on:change={changeJewel} placeholder="Please select or paste jewel" />
 
           {#if selectedJewel}
             <div class="mt-4">

--- a/frontend/src/routes/tree/+page.svelte
+++ b/frontend/src/routes/tree/+page.svelte
@@ -392,7 +392,7 @@
     }
 
     const paste = (event.clipboardData || window.clipboardData).getData('text');
-    const lines = paste.split('\n');
+    const lines = paste.split('\n').map(line => line.trim());
 
     if (lines.length < 14) {
       return;


### PR DESCRIPTION
Fix:
- Clipboard text have '\n\r' as line terminator (on Chrome Windows), and [`jewels.find((j) => j.label === lines[2])`](https://github.com/Vilsol/timeless-jewels/blob/19c0eda32c5f23ba613755aeb144b29d4102305d/frontend/src/routes/tree/%2Bpage.svelte#L401) not working. So added `String.trim()` call to remove all unused symbols.

Enhancement:
- Updated placeholder text to highlight the opportunity to paste text.

Feature:
- Added Paste feature on `frontend\src\routes\+page.svelte` page.