### PR TITLE
fix: trade query construction and default league selection

### DIFF
--- a/frontend/src/lib/skill_tree.ts
+++ b/frontend/src/lib/skill_tree.ts
@@ -389,68 +389,31 @@ export const constructQuery = (jewel: number, conqueror: string, result: SearchW
   const max_filters = 4;
   const max_query_length = max_filter_length * max_filters;
   const final_query = [];
-  const stat = {
-    type: 'count',
-    value: { min: 1 },
-    filters: [],
-    disabled: false
-  };
+  const statId = tradeStatNames[jewel][conqueror];
 
-  // single seed case
-  if (result.length == 1) {
-    for (const conq of Object.keys(tradeStatNames[jewel])) {
-      stat.filters.push({
-        id: tradeStatNames[jewel][conq],
-        value: {
-          min: result[0].seed,
-          max: result[0].seed
-        },
-        disabled: conq != conqueror
-      });
-    }
-
-    final_query.push(stat);
-    // too many results case
-  } else if (result.length > max_query_length) {
-    for (let i = 0; i < max_filters; i++) {
+  if (result.length <= max_filter_length) {
+    final_query.push({
+      type: 'count',
+      value: { min: 1 },
+      disabled: false,
+      filters: result.map((r) => ({
+        id: statId,
+        value: { min: r.seed, max: r.seed }
+      }))
+    });
+  } else {
+    const capped = result.slice(0, max_query_length);
+    for (let i = 0; i < Math.ceil(capped.length / max_filter_length); i++) {
+      const chunk = capped.slice(i * max_filter_length, (i + 1) * max_filter_length);
       final_query.push({
         type: 'count',
         value: { min: 1 },
-        filters: [],
-        disabled: i != 0
+        disabled: i !== 0,
+        filters: chunk.map((r) => ({
+          id: statId,
+          value: { min: r.seed, max: r.seed }
+        }))
       });
-    }
-
-    for (const [i, r] of result.slice(0, max_query_length).entries()) {
-      const index = Math.floor(i / max_filter_length);
-
-      final_query[index].filters.push({
-        id: tradeStatNames[jewel][conqueror],
-        value: {
-          min: r.seed,
-          max: r.seed
-        }
-      });
-    }
-  } else {
-    for (const conq of Object.keys(tradeStatNames[jewel])) {
-      stat.disabled = conq != conqueror;
-
-      for (const r of result) {
-        stat.filters.push({
-          id: tradeStatNames[jewel][conq],
-          value: {
-            min: r.seed,
-            max: r.seed
-          }
-        });
-      }
-
-      if (stat.filters.length > max_filter_length) {
-        stat.filters = stat.filters.slice(0, max_filter_length);
-      }
-
-      final_query.push(stat);
     }
   }
 

--- a/frontend/src/routes/tree/+page.svelte
+++ b/frontend/src/routes/tree/+page.svelte
@@ -454,7 +454,9 @@
     const response = await fetch('https://api.poe.watch/leagues');
     const responseJson = await response.json();
     leagues = responseJson.map((l: { name: string }) => ({ value: l.name, label: l.name }));
-    league = leagues.find((l) => l.value === localStorage.getItem('league')) || leagues[0];
+    league = leagues.find((l) => l.value === localStorage.getItem('league'))
+      || leagues.find((l) => !l.value.match(/^(Standard|Hardcore|Solo Self-Found|Ruthless|HC Ruthless|Hardcore )/i) && !l.value.startsWith('Ruthless'))
+      || leagues[0];
   };
 
   $: league && localStorage.setItem('league', league.value);


### PR DESCRIPTION
## Summary
- **Fix trade query construction**: `constructQuery()` reused a single `stat` object reference across all conquerors, causing filters to accumulate and the `disabled` flag to be overwritten. The trade URL generated was malformed with duplicate/incorrect filters. Simplified to only include the selected conqueror's filters — no need for disabled entries for other conquerors since reverse search results are specific to the selected one.
- **Fix default league selection**: The fallback `leagues[0]` picked whatever the API returned first (currently "Ruthless Mirage"). Now defaults to the current challenge league by filtering out Standard, Hardcore, SSF, and Ruthless variants.

## Test plan
- [ ] Select a jewel, conqueror, and socket location
- [ ] Run a reverse search with some stats
- [ ] Click "Trade" on an individual result — verify the trade URL has correct filters for only the selected conqueror
- [ ] Click the grouped "Trade" button — verify filters are correctly chunked without duplication
- [ ] Clear localStorage league value, reload — verify it defaults to the current challenge league (e.g. "Mirage"), not Ruthless

🤖 Generated with [Claude Code](https://claude.com/claude-code)