### PR TITLE
fix: prioritize selected conqueror in trade query

### DIFF
--- a/frontend/src/lib/skill_tree.ts
+++ b/frontend/src/lib/skill_tree.ts
@@ -433,7 +433,7 @@ export const constructQuery = (jewel: number, conqueror: string, result: SearchW
       });
     }
   } else {
-    for (const conq of Object.keys(tradeStatNames[jewel])) {
+    for (const conq of Object.keys(tradeStatNames[jewel]).sort((a, b) => a === conqueror ? -1 : b === conqueror ? 1 : 0)) {
       stat.disabled = conq != conqueror;
 
       for (const r of result) {


### PR DESCRIPTION
When the search result length does not exceed the max query length but the filter length including all conquerors does, the selected conquerer could be completely cut off by slicing the resulting filters.

This commit adds the selected conqueror first before filling up the query with unselected ones, so slicing the filters always retains the selected conqueror.

Fixes #51, #33, #31, #25

I didn't build and test it locally but by debugging the hosted version and changing the order of conquerors of my selected jewel in `tradeStatNames`l.

The resulting search was still affected by issue #26, so i got 4 stat groups filled with the same seeds and all the same conqueror, but at least they were all my selected conqueror.